### PR TITLE
Update functions.js (2) Dom. I. Adventus computation fixed

### DIFF
--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -15,7 +15,8 @@ function get_christmas_date(year) {
 }
 
 function get_christmas_weekday(christmas) {
-  return christmas.getDay();
+  if ( christmas.getDay() == 0 ) return 7;
+  else return christmas.getDay();
 }
 
 function get_first_sunday_of_advent(christmas, christmas_weekday) {
@@ -98,13 +99,13 @@ function component(date, year, month, day, weekday, before, color, header, body,
   if (date.getFullYear() != year) {
     year = date.getFullYear();
     block_new_year = '<div class="year blue mt-5">' + year + '</div>';
-    if (date.getMonth() != month) {
+    if (date.getMonth() != month || day == 1) {
       month = date.getMonth();
       block_new_month = '<div class="month green mb-3">Ianuarius</div>';
     }
   } else {
     block_new_year = '';
-    if (date.getMonth() != month) {
+    if (date.getMonth() != month || day == 1) {
       month = date.getMonth();
       block_new_month = '<div class="month green my-3">' + month_human_readable(month) + '</div>';
     } else {


### PR DESCRIPTION
Laudetur Jesus Christus! 
I found one quite serious fault and one small detail.
1. function get_christmas_weekday returned 0 for Sunday, which didn't work for get_first_sunday_of_advent (e.g. year 2022) - there were only 3 Advent Sundays... Fixed by returning "7" for Sunday. 
2. A block with new month name didn't appear, if it starts on the first day of a cycle (lent, ash, tp etc.) In previous pull request, I forgot change the new month block on the "else" part. Fixed.